### PR TITLE
small fixes for latest PyTorch & Windows (?)

### DIFF
--- a/models/vgg19_model.py
+++ b/models/vgg19_model.py
@@ -5,6 +5,8 @@ import torch
 import numpy as np
 import os
 
+from pkg_resources import parse_version
+
 def define_Vgg19(opt):
     use_gpu = len(opt.gpu_ids) > 0
     vgg19net = vgg19(models.vgg19(pretrained=True), opt)
@@ -92,7 +94,7 @@ class vgg19(nn.Module):
             deconvolved_feature_forward = self.forward(level=src_level, start_level=dst_level, set_as_var = False)
             loss_perceptual = criterionPerceptual(deconvolved_feature_forward, src_layer)
             loss_perceptual.backward()
-            error = loss_perceptual.data[0]
+            error = loss_perceptual.data[0] if parse_version(torch.__version__) <= parse_version('0.4.1') else loss_perceptual.data.item()
             self.update_last_losses(error)
             if (i % 3 == 0) and (print_errors == True):
                 print("error: ", error)

--- a/models/vgg19_model.py
+++ b/models/vgg19_model.py
@@ -123,10 +123,10 @@ class vgg19(nn.Module):
         return torch.Size([batch_size, channels[int(level)], width_layer, width_layer])
 
 class PerceptualLoss(nn.Module):
-    def __init__(self, tensor=torch.FloatTensor, size_average=True):
+    def __init__(self, tensor=torch.FloatTensor):
         super(PerceptualLoss, self).__init__()
         self.Tensor = tensor
-        self.loss = nn.MSELoss(size_average=size_average)
+        self.loss = nn.MSELoss(reduction='mean')
 
     def __call__(self, input, target_tensor):
         return self.loss(input, target_tensor)

--- a/util/MLS.py
+++ b/util/MLS.py
@@ -129,7 +129,7 @@ class MLS():
             for y in range(warped_image.shape[1]):
                 source_x = x + dxT[x, y]
                 source_y = y + dyT[x, y]
-                if source_x < warped_image.shape[0] and source_y < warped_image.shape[1]:
+                if 0 <= source_x and source_x < warped_image.shape[0] and 0 <= source_y and source_y < warped_image.shape[1]:
                     warped_image[x, y] = self.bilinear_interp(source_x, source_y, image)
         return warped_image, vxy
 

--- a/util/util.py
+++ b/util/util.py
@@ -22,7 +22,7 @@ def read_image(path, witdh):
 def get_transform(witdh):
     transform_list = []
     osize = [witdh, witdh]
-    transform_list.append(transforms.Scale(osize, Image.BICUBIC))
+    transform_list.append(transforms.Resize(osize, Image.BICUBIC))
     transform_list += [transforms.ToTensor(),
                        transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                             std=[0.229, 0.224, 0.225])]


### PR DESCRIPTION
I fixed minor issues in the latest code and certificated that it works in windows.
Here are my testing environments.  
Both are windows 10 machines and Anaconda3 (Anaconda3-2020.02-Windows-x86_64.exe) was used for Python3 installation.  
1) laptop setting
```
cudatoolkit==9.0
pillow=6.2.1
pytorch==1.1.0
torchvision==0.3.0
````
2) desktop setting
```
cudatoolkit==10.1.243
pillow=6.2.1
pytorch==1.4.0
torchvision==0.5.0
```

I am not sure the second commit is working with old PyTorch (<1.x.x), but the first commit is still useful for general users.